### PR TITLE
feat: :sparkles: Spotifyのリンク切れのためOverlayを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,10 @@ jobs:
       - name: Build ${{ matrix.package }} for ${{ matrix.system }}
         run: |
           nix build ".#${{ matrix.package }}" --print-build-logs --system ${{ matrix.system }}
+
+  build-success:
+    name: Build success
+    needs: build-packages
+    runs-on: ubuntu-24.04
+    steps:
+      - run: exit 0

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
         final: prev:
         import ./pkgs {
           pkgs = final;
+          inherit prev;
         }
         // {
           lib = prev.lib.extend (

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,4 +1,8 @@
-{ pkgs, prev ? pkgs, ... }:
+{
+  pkgs,
+  prev ? pkgs,
+  ...
+}:
 {
   claude-desktop = pkgs.callPackage ./claude-desktop { };
   fusuma = pkgs.callPackage ./fusuma { };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, prev ? pkgs, ... }:
 {
   claude-desktop = pkgs.callPackage ./claude-desktop { };
   fusuma = pkgs.callPackage ./fusuma { };
@@ -6,5 +6,6 @@
   kmonad = pkgs.callPackage ./kmonad { };
   microsoft-office = pkgs.lib.recurseIntoAttrs (pkgs.callPackage ./microsoft-office { });
   obsidian = pkgs.callPackage ./obsidian { };
+  spotify = pkgs.callPackage ./spotify { spotify = prev.spotify; };
   teams = pkgs.callPackage ./teams { };
 }

--- a/pkgs/spotify/default.nix
+++ b/pkgs/spotify/default.nix
@@ -1,0 +1,29 @@
+{
+  spotify,
+  stdenv,
+  fetchurl,
+}:
+
+# Fix hash mismatch for Darwin Spotify packages
+# Aligns with upstream PR: https://github.com/NixOS/nixpkgs/pull/470535
+# Updates to version 1.2.78.418 with corrected Wayback Machine URLs
+if stdenv.hostPlatform.isDarwin then
+  spotify.overrideAttrs (oldAttrs: {
+    version = "1.2.78.418";
+
+    src =
+      if stdenv.hostPlatform.isAarch64 then
+        fetchurl {
+          url = "https://web.archive.org/web/20251212105149/https://download.scdn.co/SpotifyARM64.dmg";
+          hash = "sha256-/rrThZOpjzaHPX1raDe5X8PqtJeTI4GDS5sXSfthXTQ=";
+        }
+      else
+        fetchurl {
+          url = "https://web.archive.org/web/20251212105140/https://download.scdn.co/Spotify.dmg";
+          hash = "sha256-N2tQTS9vHp93cRI0c5riVZ/8FSaq3ovDqh5K9aU6jV0=";
+        };
+  })
+else
+  # For Linux platforms (x86_64-linux, aarch64-linux),
+  # use the original package from nixpkgs (fetched from Snapcraft)
+  spotify


### PR DESCRIPTION
## About

NixOS/nixpkgsのSpotifyがリンク切れで別のアーカイブにリダイレクトされるため、https://github.com/NixOS/nixpkgs/pull/470535 のURLを使用したOverlayを追加