### PR TITLE
fix: :bug: karabiner-dkのアクティベーションスクリプト実行時のcodesignエラーを修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
   "nixEnvSelector.useFlakes": true,
   "explorer.fileNesting.patterns": {
     "*.nix": "${capture}.test.nix"
+  },
+  "[nix]": {
+    "editor.defaultFormatter": "brettm12345.nixfmt-vscode"
   }
 }


### PR DESCRIPTION
## Summary

- タイトル通り
- Karabiner DriverKitのExtensionインストール時にGUIがあるユーザでないとエラーが出る