### PR TITLE
fix: 🐛 `default.inputesources`まわりのバグ修正

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1765835352,
-        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
+        "lastModified": 1767609335,
+        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
+        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767026758,
-        "narHash": "sha256-7fsac/f7nh/VaKJ/qm3I338+wAJa/3J57cOGpXi0Sbg=",
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "346dd96ad74dc4457a9db9de4f4f57dab2e5731d",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
         "type": "github"
       },
       "original": {

--- a/modules/darwin/inputsources.nix
+++ b/modules/darwin/inputsources.nix
@@ -37,7 +37,7 @@ let
       cmd = "defaults write ${domain} ${escapeShellArg key} ${escapeShellArg plistValue}";
     in
     ''
-      launchctl asuser "$(id -u -- ${user})" sudo --user=${user} -- ${cmd}
+      launchctl asuser "$(id -u -- "${user}")" sudo --user="${user}" -- ${cmd}
     '';
 in
 {

--- a/modules/darwin/inputsources.nix
+++ b/modules/darwin/inputsources.nix
@@ -33,7 +33,7 @@ let
   writeUserDefault =
     domain: key: value:
     let
-      plistValue = toPlist { } value;
+      plistValue = toPlist { escape = true; } value;
       cmd = "defaults write ${domain} ${escapeShellArg key} ${escapeShellArg plistValue}";
     in
     ''


### PR DESCRIPTION
## Summary

- `lib.generators.toPlist`の`escape = false`での使用は非推奨のため`escape = true`を指定
   Ref: https://github.com/NixOS/nixpkgs/blob/f560ccec6b1116b22e6ed15f4c510997d99d5852/lib/generators.nix#L703-L710
- word splittingのためコマンド置換をクオート