### PR TITLE
fix: zed-editorのCLIがnix storeパスで起動できない問題を修正

### DIFF
--- a/pkgs/overlays/matrix.nix
+++ b/pkgs/overlays/matrix.nix
@@ -34,4 +34,6 @@ lib.flatten [
   (mkEntry "swiftlint" { updatable = true; })
   # zen-browser: only included when present in nixpkgs
   (mkEntry "zen-browser" { })
+  # zed-editor: Darwin-only wrapper to fix CLI hanging via nix store path
+  (mkEntry "zed-editor" { })
 ]

--- a/pkgs/overlays/zed-editor.nix
+++ b/pkgs/overlays/zed-editor.nix
@@ -1,0 +1,34 @@
+# Fix zed-editor CLI hanging when invoked via the nixpkgs-installed `zeditor` command.
+#
+# Root cause:
+#   The CLI binary uses `current_exe().canonicalize()` to find its app bundle path.
+#   When installed via nixpkgs, the symlink chain resolves to:
+#     /nix/store/<hash>/Applications/Zed.app/Contents/MacOS/cli
+#   The CLI then passes this nix store path to macOS `LSOpenFromURLSpec`, which
+#   either fails or launches the wrong Zed instance, leaving the IPC server
+#   waiting forever.
+#
+# Fix:
+#   Wrap `zeditor` with `--zed "$HOME/Applications/Home Manager Apps/Zed.app"`.
+#   This tells the CLI to use the Home Manager-managed app bundle, which is a real
+#   directory (not a symlink), so `canonicalize()` does not resolve into /nix/store,
+#   and macOS Launch Services can launch it successfully.
+#
+#   `wrapProgram` (makeShellWrapper) is used intentionally over `makeBinaryWrapper`
+#   because it generates a shell script where `$HOME` is expanded at runtime,
+#   correctly handling the space-containing path "Home Manager Apps".
+
+final: prev:
+prev.lib.optionalAttrs prev.stdenv.hostPlatform.isDarwin {
+  zed-editor = prev.symlinkJoin {
+    name = "zed-editor-${prev.zed-editor.version}";
+    paths = [ prev.zed-editor ];
+    nativeBuildInputs = [ prev.makeWrapper ];
+    postBuild = ''
+      wrapProgram $out/bin/zeditor \
+        --add-flags "--zed \"\$HOME/Applications/Home Manager Apps/Zed.app\""
+    '';
+    meta = prev.zed-editor.meta;
+    passthru = prev.zed-editor.passthru or { };
+  };
+}


### PR DESCRIPTION
## 問題

nixpkgsで入れた `zeditor` コマンドを引数付きで実行すると、何も起きずコマンドが完了しない。

```sh
zeditor .   # ← ハングする
zeditor --version   # ← 正常に動作する
```

## 根本原因

`cli` バイナリは起動時に `current_exe().canonicalize()` で自身のパスを取得し、`.app` バンドルを探す。

nixpkgsでインストールした場合のシンボリックリンクチェーン:

```
zeditor
  → /nix/store/.../bin/zeditor (symlink)
    → /nix/store/.../Applications/Zed.app/Contents/MacOS/cli (実体)
```

`canonicalize()` が全symlinkを解決するため、`locate_bundle()` は `/nix/store/.../Zed.app` を返す。CLI はこのパスを macOS の `LSOpenFromURLSpec` に渡すが、macOS は `/nix/store/` 下のアプリを Launch Services 経由で起動できない（または誤ったインスタンスを起動する）ため、IPC サーバーが永遠に待ち続けてハングする。

`--version` / `--help` が動くのは、アプリ起動処理の前に `return` するため。

## 修正方法

CLI の `--zed` フラグで `LSOpenFromURLSpec` に渡す appURL を差し替えられる。`wrapProgram`（makeShellWrapper）で `--zed "$HOME/Applications/Home Manager Apps/Zed.app"` を常に付与する。

- `~/Applications/Home Manager Apps/Zed.app` は Home Manager が作成した実ディレクトリ（symlinkでない）
- `canonicalize()` が nix store に解決されないため、macOS が正常に起動できる
- `wrapProgram`（shell スクリプト型）を使うことで `$HOME` が実行時に展開される
- スペースを含むパス（`Home Manager Apps`）も正しく1引数として渡される

## 変更内容

- `pkgs/overlays/zed-editor.nix` を新規追加: Darwin のみ `zeditor` を `wrapProgram` でラップ
- `pkgs/overlays/matrix.nix` に `zed-editor` エントリを追加